### PR TITLE
List Silver Hen Tech Token 

### DIFF
--- a/assets/CCAE2AI67RNYJL6GYEHWBTFVCFEI3DNW3VMK26N7ZZKA75IUFVCF2GIJ3.json
+++ b/assets/CCAE2AI67RNYJL6GYEHWBTFVCFEI3DNW3VMK26N7ZZKA75IUFVCF2GIJ3.json
@@ -1,0 +1,10 @@
+{
+  "code": "SHT",
+  "issuer": "GCBJGB67Z2UTZVXVPYFF2KZ4P5ZEEVCZWRGYBLN3CZCG63VOF6LNSPEE",
+  "contract": "CAE2AI67RNYJL6GYEHWBTFVCFEI3DNW3VMK26N7ZZKA75IUFVCF2GIJ3",
+  "name": "SHT Token",
+  "org": "Silver Hen Tech",
+  "domain": "zomb.fun",
+  "icon": "https://zomb.fun/assets/images/sht-logo.png",
+  "decimals": 7
+}


### PR DESCRIPTION
Greetings Again,

Requesting to list Silver Hen Tech Token

The supply is capped at 420 million tokens.

The issuer account is locked

Silver Hen Tech Token will be the token that powers our NFT and Retail Store at zomb.fun

The TOML can be found at https://zomb.fun/.well-known/stellar.toml

There is a request for a dirctory listing at stellar.expert https://github.com/stellar-expert/public-directory/issues/729 pending

Contact Us: info@zomb.fun

Thank You 