### PR TITLE
Add Silver Hen Tech Token (Fixed) (Website Up)

### DIFF
--- a/assets/CAE2AI67RNYJL6GYEHWBTFVCFEI3DNW3VMK26N7ZZKA75IUFVCF2GIJ3.json
+++ b/assets/CAE2AI67RNYJL6GYEHWBTFVCFEI3DNW3VMK26N7ZZKA75IUFVCF2GIJ3.json
@@ -1,0 +1,10 @@
+{
+  "name": "SHT",
+  "code": "SHT",
+  "issuer": "GCBJGB67Z2UTZVXVPYFF2KZ4P5ZEEVCZWRGYBLN3CZCG63VOF6LNSPEE",
+  "contract": "CAE2AI67RNYJL6GYEHWBTFVCFEI3DNW3VMK26N7ZZKA75IUFVCF2GIJ3",
+  "org": "Silver Hen Tech",
+  "domain": "zomb.fun",
+  "icon": "https://zomb.fun/images/sht-logo.png",
+  "decimals": 7
+}


### PR DESCRIPTION
Greetings Again,

Requesting to list Silver Hen Tech Token

The supply is capped at 420 million tokens.

The issuer account is locked

Silver Hen Tech Token will be amongst the tokens that power ourDeFi, NFT, and IRL Retail Store at zomb.fun

The TOML can be found at https://zomb.fun/.well-known/stellar.toml

https://zomb.fun/

Contact Us: info@zomb.fun

Thank You