### PR TITLE
Add Centrifuge tokens (deJTRSY, deJAAA)

### DIFF
--- a/assets/CBI7UCH5KGSVQRO5H4SUCZUTZABCITZLRHQQZTWL2TK4RZ72TAR6IHRV.json
+++ b/assets/CBI7UCH5KGSVQRO5H4SUCZUTZABCITZLRHQQZTWL2TK4RZ72TAR6IHRV.json
@@ -1,0 +1,7 @@
+{
+  "name": "deJTRSY",
+  "contract": "CBI7UCH5KGSVQRO5H4SUCZUTZABCITZLRHQQZTWL2TK4RZ72TAR6IHRV",
+  "org": "Centrifuge",
+  "icon": "https://centrifuge.mypinata.cloud/ipfs/bafkreieracb5e57bhg7bphd7sp4hxf3yhbm3cxinst3o5mennfosagkxuu",
+  "decimals": 18
+}

--- a/assets/CC64WBDGS6QQP22QTTIACYIXT3WF7BBQEYOQPLTP7GTKYY7PZ74QYGSL.json
+++ b/assets/CC64WBDGS6QQP22QTTIACYIXT3WF7BBQEYOQPLTP7GTKYY7PZ74QYGSL.json
@@ -1,0 +1,7 @@
+{
+  "name": "deJAAA",
+  "contract": "CC64WBDGS6QQP22QTTIACYIXT3WF7BBQEYOQPLTP7GTKYY7PZ74QYGSL",
+  "org": "Centrifuge",
+  "icon": "https://centrifuge.mypinata.cloud/ipfs/bafkreifp5ww5lpbgrny36oxgzg2kjw2226lmj2vmekp4nqemm5ewhhtmwi",
+  "decimals": 18
+}


### PR DESCRIPTION
 ## Summary                                                                                                          
  - Adds deJTRSY (Wrapped Tokenized US Treasury Bills)                                                                
  - Adds deJAAA (Wrapped Tokenized AAA-rated CLOs)                                                                    
                                                                                                                      
  Both tokens are issued by Centrifuge on Stellar/Soroban.                                                            
                                                                                                                      
  ## Token Details                                                                                                    
                                                                                                                      
  **deJTRSY**                                                                                                         
  - Contract: `CBI7UCH5KGSVQRO5H4SUCZUTZABCITZLRHQQZTWL2TK4RZ72TAR6IHRV`                                              
  - Decimals: 18                                                                                                      
                                                                                                                      
  **deJAAA**                                                                                                          
  - Contract: `CC64WBDGS6QQP22QTTIACYIXT3WF7BBQEYOQPLTP7GTKYY7PZ74QYGSL`                                              
  - Decimals: 18                                                      