### PR TITLE
Add MGUSD (MoneyGram USD)

### DIFF
--- a/assets/CDK2LDSYUKPEFN3HNE7K7ETUT3VIOBHSOXAK5CTO4A4RKKZQUCAIWCJA.json
+++ b/assets/CDK2LDSYUKPEFN3HNE7K7ETUT3VIOBHSOXAK5CTO4A4RKKZQUCAIWCJA.json
@@ -1,0 +1,10 @@
+{
+  "code": "MGUSD",
+  "issuer": "GAIUGZZZSL47BKH27SUDZESZELFJDPE2UM52RACOSFJ7BIVBGKUEJSUZ",
+  "contract": "CDK2LDSYUKPEFN3HNE7K7ETUT3VIOBHSOXAK5CTO4A4RKKZQUCAIWCJA",
+  "name": "MoneyGram USD",
+  "org": "MoneyGram Payment Systems",
+  "domain": "mgusd.moneygram.com",
+  "icon": "https://mgusd.moneygram.com/mgusd-logo.jpeg",
+  "decimals": 7
+}

--- a/assets/CDK2LDSYUKPEFN3HNE7K7ETUT3VIOBHSOXAK5CTO4A4RKKZQUCAIWCJA.json
+++ b/assets/CDK2LDSYUKPEFN3HNE7K7ETUT3VIOBHSOXAK5CTO4A4RKKZQUCAIWCJA.json
@@ -3,7 +3,7 @@
   "issuer": "GAIUGZZZSL47BKH27SUDZESZELFJDPE2UM52RACOSFJ7BIVBGKUEJSUZ",
   "contract": "CDK2LDSYUKPEFN3HNE7K7ETUT3VIOBHSOXAK5CTO4A4RKKZQUCAIWCJA",
   "name": "MoneyGram USD",
-  "org": "MoneyGram Payment Systems",
+  "org": "MoneyGram",
   "domain": "mgusd.moneygram.com",
   "icon": "https://mgusd.moneygram.com/mgusd-logo.jpeg",
   "decimals": 7


### PR DESCRIPTION
Adds MGUSD, MoneyGram's USD-backed stablecoin issued on Stellar mainnet (deployed via Bridge on behalf of MoneyGram).

- Code: `MGUSD`
- Issuer: `GAIUGZZZSL47BKH27SUDZESZELFJDPE2UM52RACOSFJ7BIVBGKUEJSUZ`
- SAC contract: `CDK2LDSYUKPEFN3HNE7K7ETUT3VIOBHSOXAK5CTO4A4RKKZQUCAIWCJA`
- Home domain: `mgusd.moneygram.com` ([stellar.toml](https://mgusd.moneygram.com/.well-known/stellar.toml))
- Stellar.Expert: https://stellar.expert/explorer/public/asset/MGUSD-GAIUGZZZSL47BKH27SUDZESZELFJDPE2UM52RACOSFJ7BIVBGKUEJSUZ

`yarn verify` passes locally:
- Domain matches issuer's on-chain `home_domain`
- Derived SAC contract matches the deployed one
- Asset has active trustlines on Horizon
- Icon URL returns `image/jpeg`