### PR TITLE
Add XLD (XLM Domains) token

### DIFF
--- a/assets/CDNDPEI4X6NYKEVAIOH2T3AIVYOWY6LDT7RITBTT3XXTIETTUSATZQ7A.json
+++ b/assets/CDNDPEI4X6NYKEVAIOH2T3AIVYOWY6LDT7RITBTT3XXTIETTUSATZQ7A.json
@@ -1,0 +1,10 @@
+{
+  "code": "XLD",
+  "issuer": "GBE6IZPK5MPLVPMD3NZ2YW5BY4GBB5IDYDXTIERGA3A5S2XANCUCTXLD",
+  "contract": "CDNDPEI4X6NYKEVAIOH2T3AIVYOWY6LDT7RITBTT3XXTIETTUSATZQ7A",
+  "name": "XLM Domains",
+  "org": "XLM Domains",
+  "domain": "xlm.domains",
+  "icon": "https://xlm.domains/favicon.png",
+  "decimals": 7
+}


### PR DESCRIPTION
## Token: XLD (XLM Domains)

- **Code:** XLD
- **Contract:** `CDNDPEI4X6NYKEVAIOH2T3AIVYOWY6LDT7RITBTT3XXTIETTUSATZQ7A`
- **Issuer:** `GBE6IZPK5MPLVPMD3NZ2YW5BY4GBB5IDYDXTIERGA3A5S2XANCUCTXLD`
- **Decimals:** 7
- **Domain:** https://xlm.domains
- **stellar.toml:** https://xlm.domains/.well-known/stellar.toml

XLD is the yield-bearing vault receipt token for [XLM Domains](https://xlm.domains) — every .xlm domain is a yield-bearing NFT backed 100% by USTRY.

**Issuer is permanently locked** (master weight = 0, locked 2026-04-22).

### Existing Aquarius AMM Pools
| Pool | TVL | Fee |
|---|---|---|
| **USDC / XLD** | $642 | 0.3% |
| **XLM / XLD** | $570 | 0.3% |
| **AQUA / XLD** | $1.34K | 0.3% |
| **USTRY / XLD** | $101 | 0.3% |

### Verification
- [stellar.toml](https://xlm.domains/.well-known/stellar.toml) ✅
- [Stellar.Expert asset page](https://stellar.expert/explorer/public/asset/XLD-GBE6IZPK5MPLVPMD3NZ2YW5BY4GBB5IDYDXTIERGA3A5S2XANCUCTXLD) ✅
- Issuer locked ✅