### PR TITLE
Add USDT0 token

### DIFF
--- a/assets/CBSJZEIO5C7KC2SF3MKSNXXJSW5G3VTNBX4ATMKUI3B2MR4JKM4R26YF.json
+++ b/assets/CBSJZEIO5C7KC2SF3MKSNXXJSW5G3VTNBX4ATMKUI3B2MR4JKM4R26YF.json
@@ -1,0 +1,9 @@
+{
+  "code": "USDT0",
+  "issuer": "GATISXX6BZ6NC7IKQBY37CJD4SOZL3CYZJWXEDG6JVIY4WBS6KXJHN6Q",
+  "contract": "CBSJZEIO5C7KC2SF3MKSNXXJSW5G3VTNBX4ATMKUI3B2MR4JKM4R26YF",
+  "name": "USDT0",
+  "org": "USDT0",
+  "icon": "https://ipfs.io/ipfs/bafkreifaalohkkikosp27qp6qczwaffwseejvoaafkgv7ahyrqvejmpqou",
+  "decimals": 7
+}


### PR DESCRIPTION
## Add USDT0

USDT0 is Tether's omnichain USDT, transported via LayerZero OFT (https://usdt0.to, https://docs.usdt0.to). This PR adds the Stellar deployment, live on mainnet since 2026-07-26. Submitted by the team operating the deployment.

Contracts listed here: https://docs.usdt0.to/technical-documentation/deployments?q=stellar

**Asset:** `USDT0:GATISXX6BZ6NC7IKQBY37CJD4SOZL3CYZJWXEDG6JVIY4WBS6KXJHN6Q`
**SAC:** `CBSJZEIO5C7KC2SF3MKSNXXJSW5G3VTNBX4ATMKUI3B2MR4JKM4R26YF`

`yarn verify` passes locally (new-asset path: domain ✓, contract derivation ✓, asset records ✓, icon ✓).